### PR TITLE
Add an Elasticsearch client

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -119,6 +119,20 @@ Common definition for curator:
                   unit: days
                   unit_count: 2
 
+Client setup
+------------
+
+Client with host and port
+
+.. code-block:: yaml
+
+    elasticsearch:
+      client:
+        enabled: true
+        server:
+          host: elasticsearch.host
+          port: 9200
+
 Read more
 =========
 

--- a/elasticsearch/client.sls
+++ b/elasticsearch/client.sls
@@ -1,0 +1,11 @@
+{%- from "elasticsearch/map.jinja" import client with context %}
+{%- if client.get('enabled', False) %}
+
+/etc/salt/minion.d/_elasticsearch.conf:
+  file.managed:
+  - source: salt://elasticsearch/files/_elasticsearch.conf
+  - template: jinja
+  - user: root
+  - group: root
+
+{%- endif %}

--- a/elasticsearch/files/_elasticsearch.conf
+++ b/elasticsearch/files/_elasticsearch.conf
@@ -1,0 +1,4 @@
+{%- from "elasticsearch/map.jinja" import client with context %}
+
+elasticsearch:
+  host: {{client.server.host}}:{{client.server.port}}

--- a/elasticsearch/init.sls
+++ b/elasticsearch/init.sls
@@ -1,5 +1,10 @@
 
-{% if pillar.elasticsearch.server is defined %}
+{%- if pillar.elasticsearch is defined %}
 include:
+{%- if pillar.elasticsearch.server is defined %}
 - elasticsearch.server
-{% endif %}
+{%- endif %}
+{%- if pillar.elasticsearch.client is defined %}
+- elasticsearch.client
+{%- endif %}
+{%- endif %}

--- a/elasticsearch/map.jinja
+++ b/elasticsearch/map.jinja
@@ -18,3 +18,12 @@ RedHat:
 {%- endload %}
 
 {%- set server = salt['grains.filter_by'](base_defaults, merge=salt['pillar.get']('elasticsearch:server')) %}
+
+{%- load_yaml as client_defaults %}
+default:
+  server:
+    host: 127.0.0.1
+    port: 9200
+{%- endload %}
+
+{%- set client = salt['grains.filter_by'](client_defaults, merge=salt['pillar.get']('elasticsearch:client')) %}

--- a/metadata/service/client.yml
+++ b/metadata/service/client.yml
@@ -1,0 +1,6 @@
+applications:
+- elasticsearch.client
+parameters:
+  elasticsearch:
+    client:
+      enabled: true


### PR DESCRIPTION
This patch adds a client. The client will be responsible to push new
indexes and new templates to Elasticsearch.