### PR TITLE
Add Elasticsearch index templates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -122,7 +122,7 @@ Common definition for curator:
 Client setup
 ------------
 
-Client with host and port
+Client with host and port:
 
 .. code-block:: yaml
 
@@ -132,6 +132,22 @@ Client with host and port
         server:
           host: elasticsearch.host
           port: 9200
+
+Client where you download an index template that is stored in the direcotry
+*files/*:
+
+.. code-block:: yaml
+
+    elasticsearch:
+      client:
+        enabled: true
+        server:
+          host: elasticsearch.host
+          port: 9200
+        index:
+          my_index:
+            enabled: true
+            template: elasticsearch/files/my_index_template.json
 
 Read more
 =========

--- a/elasticsearch/client.sls
+++ b/elasticsearch/client.sls
@@ -8,4 +8,17 @@
   - user: root
   - group: root
 
+{%- for index_name, index in client.get('index', {}).iteritems() %}
+elasticsearch_index_{{ index_name }}:
+  {%- if index.get('enabled', False) %}
+  elasticsearch_index_template.present:
+  {%- import_json index.template as definition %}
+  - name: {{ index_name }}
+  - definition: '{{ definition|json }}'
+  {%- else %}
+  elasticsearch_index_template.absent:
+  - name: {{ index_name }}
+  {%- endif %}
+{%- endfor %}
+
 {%- endif %}

--- a/elasticsearch/files/es_template_kibana4.json
+++ b/elasticsearch/files/es_template_kibana4.json
@@ -1,0 +1,135 @@
+{
+    "mappings" : {
+      "index-pattern" : {
+        "properties" : {
+          "fieldFormatMap" : {
+            "type" : "string"
+          },
+          "fields" : {
+            "type" : "string"
+          },
+          "intervalName" : {
+            "type" : "string"
+          },
+          "notExpandable" : {
+            "type" : "boolean"
+          },
+          "timeFieldName" : {
+            "type" : "string"
+          },
+          "title" : {
+            "type" : "string"
+          }
+        }
+      },
+      "config" : {
+        "properties" : {
+          "buildNum" : {
+            "type" : "string",
+            "index" : "not_analyzed"
+          }
+        }
+      },
+      "search" : {
+        "properties" : {
+          "columns" : {
+            "type" : "string"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "hits" : {
+            "type" : "integer"
+          },
+          "kibanaSavedObjectMeta" : {
+            "properties" : {
+              "searchSourceJSON" : {
+                "type" : "string"
+              }
+            }
+          },
+          "sort" : {
+            "type" : "string"
+          },
+          "title" : {
+            "type" : "string"
+          },
+          "version" : {
+            "type" : "integer"
+          }
+        }
+      },
+      "visualization" : {
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "kibanaSavedObjectMeta" : {
+            "properties" : {
+              "searchSourceJSON" : {
+                "type" : "string"
+              }
+            }
+          },
+          "savedSearchId" : {
+            "type" : "string"
+          },
+          "title" : {
+            "type" : "string"
+          },
+          "uiStateJSON" : {
+            "type" : "string"
+          },
+          "version" : {
+            "type" : "integer"
+          },
+          "visState" : {
+            "type" : "string"
+          }
+        }
+      },
+      "dashboard" : {
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "hits" : {
+            "type" : "integer"
+          },
+          "kibanaSavedObjectMeta" : {
+            "properties" : {
+              "searchSourceJSON" : {
+                "type" : "string"
+              }
+            }
+          },
+          "optionsJSON" : {
+            "type" : "string"
+          },
+          "panelsJSON" : {
+            "type" : "string"
+          },
+          "timeFrom" : {
+            "type" : "string"
+          },
+          "timeRestore" : {
+            "type" : "boolean"
+          },
+          "timeTo" : {
+            "type" : "string"
+          },
+          "title" : {
+            "type" : "string"
+          },
+          "uiStateJSON" : {
+            "type" : "string"
+          },
+          "version" : {
+            "type" : "integer"
+          }
+        }
+      }
+    },
+    "template": ".kibana"
+}
+

--- a/elasticsearch/files/es_template_log.json
+++ b/elasticsearch/files/es_template_log.json
@@ -1,0 +1,112 @@
+{
+    "mappings": {
+        "message": {
+            "properties": {
+                "Logger": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
+                "Hostname": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
+                "Pid": {
+                    "index": "not_analyzed",
+                    "type": "long"
+                },
+                "Severity": {
+                    "index": "not_analyzed",
+                    "type": "long"
+                },
+                "Type": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
+                "programname": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
+                "python_module": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
+                "severity_label": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
+                "environment_label": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
+                "openstack_roles": {
+                    "type": "string",
+                    "analyzer": "ost_roles"
+                },
+                "openstack_region": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
+                "openstack_release": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
+                "deployment_id": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
+                "request_id": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
+                "tenant_id": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
+                "user_id": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
+                "instance_id": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
+                "http_response_time": {
+                    "type": "float"
+                },
+                "http_status": {
+                    "type": "integer"
+                },
+                "http_method": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
+                "http_url": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
+                "http_version": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                }
+            }
+        }
+    },
+    "settings": {
+        "analysis": {
+            "tokenizer": {
+                 "comma" : {
+                     "type": "pattern",
+                     "pattern": ","
+                 }
+            },
+            "analyzer": {
+                 "ost_roles": {
+                     "type": "custom",
+                     "tokenizer": "comma",
+                     "filter": ["lowercase"]
+                 }
+            }
+        }
+    },
+    "template": "log-*"
+}

--- a/elasticsearch/files/es_template_notification.json
+++ b/elasticsearch/files/es_template_notification.json
@@ -1,0 +1,109 @@
+{
+    "mappings": {
+        "message": {
+            "properties": {
+                "event_type": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
+                "Payload": {
+                    "type": "string"
+                },
+                "Logger": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
+                "programname": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
+                "Hostname": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
+                "hostname": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
+                "Pid": {
+                    "index": "not_analyzed",
+                    "type": "long"
+                },
+                "Severity": {
+                    "index": "not_analyzed",
+                    "type": "long"
+                },
+                "syslogfacility": {
+                    "index": "not_analyzed",
+                    "type": "long"
+                },
+                "Type": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
+                "severity_label": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
+                "environment_label": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
+                "openstack_role": {
+                    "type": "string",
+                    "analyzer": "ost_roles"
+                },
+                "openstack_region": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
+                "openstack_release": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
+                "deployment_id": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
+                "request_id": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
+                "tenant_id": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
+                "user_id": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
+                "launched_at": {
+                    "type": "date",
+                    "format": "dateOptionalTime"
+                },
+                "created_at": {
+                    "type": "date",
+                    "format": "dateOptionalTime"
+                }
+            }
+        }
+    },
+    "settings": {
+        "analysis": {
+            "tokenizer": {
+                 "comma" : {
+                     "type": "pattern",
+                     "pattern": ","
+                 }
+            },
+            "analyzer": {
+                 "ost_roles": {
+                     "type": "custom",
+                     "tokenizer": "comma",
+                     "filter": ["lowercase"]
+                 }
+            }
+        }
+    },
+    "template": "notification-*"
+}

--- a/metadata/service/client.yml
+++ b/metadata/service/client.yml
@@ -4,3 +4,13 @@ parameters:
   elasticsearch:
     client:
       enabled: true
+      index:
+        log:
+          enabled: true
+          template: elasticsearch/files/es_template_log.json
+        notification:
+          enabled: true
+          template: elasticsearch/files/es_template_notification.json
+        kibana4:
+          enabled: true
+          template: elasticsearch/files/es_template_kibana4.json


### PR DESCRIPTION
This patch adds three index templates that are used by StackLight.