### PR TITLE
Use default value for shards and replicas

### DIFF
--- a/metadata/service/server/local.yml
+++ b/metadata/service/server/local.yml
@@ -10,7 +10,6 @@ parameters:
         address: 127.0.0.1
         port: 9200
       index:
-        shards: 1
         replicas: 0
       cluster:
         multicast: false

--- a/metadata/service/server/single.yml
+++ b/metadata/service/server/single.yml
@@ -10,7 +10,6 @@ parameters:
         address: 0.0.0.0
         port: 9200
       index:
-        shards: 1
         replicas: 0
       cluster:
         multicast: false


### PR DESCRIPTION
This patch removes the override of the shards and replicas values. This
will be set in the model because it depends of your infrastructure.