### PR TITLE
Salt module elasticsearch depends on elasticsearch-py

### DIFF
--- a/elasticsearch/client.sls
+++ b/elasticsearch/client.sls
@@ -8,6 +8,10 @@
   - user: root
   - group: root
 
+elasticsearch_client_packages:
+  pkg.installed:
+  - names: {{ client.pkgs }}
+
 {%- for index_name, index in client.get('index', {}).iteritems() %}
 elasticsearch_index_{{ index_name }}:
   {%- if index.get('enabled', False) %}
@@ -19,6 +23,8 @@ elasticsearch_index_{{ index_name }}:
   elasticsearch_index_template.absent:
   - name: {{ index_name }}
   {%- endif %}
+  - require:
+    - pkg: elasticsearch_client_packages
 {%- endfor %}
 
 {%- endif %}

--- a/elasticsearch/map.jinja
+++ b/elasticsearch/map.jinja
@@ -20,7 +20,15 @@ RedHat:
 {%- set server = salt['grains.filter_by'](base_defaults, merge=salt['pillar.get']('elasticsearch:server')) %}
 
 {%- load_yaml as client_defaults %}
-default:
+Debian:
+  pkgs:
+  - python-elasticsearch
+  server:
+    host: 127.0.0.1
+    port: 9200
+RedHat:
+  pkgs:
+  - python-elasticsearch
   server:
     host: 127.0.0.1
     port: 9200


### PR DESCRIPTION
This patch installs pip and the python client.