### PR TITLE
Separate the configuration and other part fo the client

### DIFF
--- a/elasticsearch/client/init.sls
+++ b/elasticsearch/client/init.sls
@@ -1,16 +1,8 @@
 {%- from "elasticsearch/map.jinja" import client with context %}
 {%- if client.get('enabled', False) %}
 
-/etc/salt/minion.d/_elasticsearch.conf:
-  file.managed:
-  - source: salt://elasticsearch/files/_elasticsearch.conf
-  - template: jinja
-  - user: root
-  - group: root
-
-elasticsearch_client_packages:
-  pkg.installed:
-  - names: {{ client.pkgs }}
+include:
+  - elasticsearch.client.service
 
 {%- for index_name, index in client.get('index', {}).iteritems() %}
 elasticsearch_index_{{ index_name }}:

--- a/elasticsearch/client/service.sls
+++ b/elasticsearch/client/service.sls
@@ -1,0 +1,15 @@
+{%- from "elasticsearch/map.jinja" import client with context %}
+{%- if client.get('enabled', False) %}
+
+/etc/salt/minion.d/_elasticsearch.conf:
+  file.managed:
+  - source: salt://elasticsearch/files/_elasticsearch.conf
+  - template: jinja
+  - user: root
+  - group: root
+
+elasticsearch_client_packages:
+  pkg.installed:
+  - names: {{ client.pkgs }}
+
+{%- endif %}


### PR DESCRIPTION
This patch separates the configuration of the client and the creation of
the Kibana objects into Elasticsearch. A restart of the minion is needed
between those two parts so we separate them to allow it. This means that
you need to call the state client.objects explicitly to create objects.