### PR TITLE
Change policy for the elasticsearch_service cluster

### DIFF
--- a/elasticsearch/meta/heka.yml
+++ b/elasticsearch/meta/heka.yml
@@ -60,7 +60,7 @@ remote_collector:
 aggregator:
   alarm_cluster:
     elasticsearch_service:
-      policy: majority_of_members
+      policy: availability_of_members
       alerting: enabled
       group_by: hostname
       match:


### PR DESCRIPTION
This change updates the policy to availability_of_members to trigger an
alert whenever a node is down.