### PR TITLE
Use the availability_of_members policy

### DIFF
--- a/elasticsearch/meta/heka.yml
+++ b/elasticsearch/meta/heka.yml
@@ -60,7 +60,7 @@ remote_collector:
 aggregator:
   alarm_cluster:
     elasticsearch_service:
-      policy: majority_of_members
+      policy: availability_of_members
       alerting: enabled
       group_by: hostname
       match:


### PR DESCRIPTION
Use the availability_of_members policy for the elasticsearch_service alarm cluster definition.