### PR TITLE
Fix templating to get the name of nodes

### DIFF
--- a/elasticsearch/files/grafana_dashboards/elasticsearch_influxdb.json
+++ b/elasticsearch/files/grafana_dashboards/elasticsearch_influxdb.json
@@ -1268,7 +1268,7 @@
         "includeAll": false,
         "name": "server",
         "options": [],
-        "query": "show tag values from elasticsearch_cluster_health with key = \"hostname\" where environment_label =~ /^$environment$/",
+        "query": "show tag values from elasticsearch_check with key = \"hostname\" where environment_label =~ /^$environment$/",
         "refresh": 1,
         "refresh_on_load": true,
         "regex": "",


### PR DESCRIPTION
This patch modifies the query used to get the name of Elasticsearch
instances.