### PR TITLE
Extend template definition options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -145,7 +145,7 @@ Client with host and port:
           host: elasticsearch.host
           port: 9200
 
-Client where you download an index template that is stored in the direcotry
+Client where you download an index template that is stored in the directory
 *files/*:
 
 .. code-block:: yaml
@@ -160,6 +160,37 @@ Client where you download an index template that is stored in the direcotry
           my_index:
             enabled: true
             template: elasticsearch/files/my_index_template.json
+
+Client where you download an index template from the metadata definition and force index creation:
+
+.. code-block:: yaml
+
+    elasticsearch:
+      client:
+        enabled: true
+        server:
+          host: elasticsearch.host
+          port: 9200
+        index:
+          my_index:
+            enabled: true
+            force_operation: true
+            definition:
+              template: notifications
+              settings:
+                number_of_shards: 5
+                number_of_replicas: 1
+              mappings:
+                notification:
+                  properties:
+                    applicationId:
+                      type: long
+                    content:
+                      type: text
+                      fields:
+                        keyword:
+                          type: keyword
+                          ignore_above: 256
 
 Read more
 =========

--- a/elasticsearch/client/init.sls
+++ b/elasticsearch/client/init.sls
@@ -6,17 +6,44 @@ include:
 
 {%- for index_name, index in client.get('index', {}).iteritems() %}
 elasticsearch_index_{{ index_name }}:
+
   {%- if index.get('enabled', False) %}
-  elasticsearch_index_template.present:
+  {% set operation = 'create' %}
+
+  {%- if index.definition is defined %}
+  {% set definition = index.definition %}
+  {%- endif %}
+
+  {%- if index.template is defined %}
   {%- import_json index.template as definition %}
+  {%- endif %}
+
+  {%- if definition is defined %}
+  elasticsearch_index_template.present:
   - name: {{ index_name }}
   - definition: '{{ definition|json }}'
   {%- else %}
+  cmd.run:
+  - name: echo "No definition specified for index {{ index_name }}"
+  {%- endif %}
+
+  {%- else %}
+
+  {% set operation = 'delete' %}
   elasticsearch_index_template.absent:
   - name: {{ index_name }}
   {%- endif %}
+
   - require:
     - pkg: elasticsearch_client_packages
+
+{%- if index.get('force_operation', False) %}
+elasticsearch_index_{{ index_name }}_{{ operation }}:
+  module.run:
+    - name: elasticsearch.index_{{ operation }}
+    - index: {{ index_name }}
+{%- endif %}
+
 {%- endfor %}
 
 {%- endif %}


### PR DESCRIPTION
This change adds:
  - support for template definition from the metadata
  - forcing index creation from the defined template